### PR TITLE
FederatedStoreManager: enable selection of correct store manager

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
     </parent>
 
     <artifactId>datanucleus-core</artifactId>
-    <version>4.1.7</version>
+    <version>4.1.7-mc1</version>
 
     <name>DataNucleus Core</name>
     <description>

--- a/src/main/java/org/datanucleus/store/federation/FederatedStoreManager.java
+++ b/src/main/java/org/datanucleus/store/federation/FederatedStoreManager.java
@@ -35,6 +35,7 @@ import org.datanucleus.PropertyNames;
 import org.datanucleus.api.ApiAdapter;
 import org.datanucleus.exceptions.NucleusUserException;
 import org.datanucleus.flush.FlushProcess;
+import org.datanucleus.identity.SingleFieldId;
 import org.datanucleus.metadata.AbstractClassMetaData;
 import org.datanucleus.metadata.AbstractMemberMetaData;
 import org.datanucleus.metadata.MetaDataManager;
@@ -332,7 +333,10 @@ public class FederatedStoreManager implements StoreManager
     {
         NucleusLogger.PERSISTENCE.debug(">> TODO Need to allocate manageClassForIdentity(" + id + ") to correct store manager");
         // TODO Work out if this class is in this store manager
-        return primaryStoreMgr.manageClassForIdentity(id, clr);
+		if(id instanceof SingleFieldId){
+			return  getStoreManagerForClass(((SingleFieldId)id).getTargetClassName(), clr).manageClassForIdentity(id, clr);
+		}
+		return primaryStoreMgr.manageClassForIdentity(id, clr);
     }
 
     public boolean managesClass(String className)


### PR DESCRIPTION
This change allows us to use the federated store manager in an Apache Isis (http://isis.apache.org) application. It fixes an exception which appeared when trying to configure multiple stores in an Isis application. And with this change, entities are correctly persisted in different databases.

This is probably a very naive approach and definitely not sufficient, as there are several other TODO comments in the code base, but if you could point us to what else has to be done, we could provide a better patch.

Thank you
